### PR TITLE
Remove unused email param from time_range

### DIFF
--- a/docs/resources/time_range.md
+++ b/docs/resources/time_range.md
@@ -9,7 +9,6 @@ and delete time ranges from a manager.
 resource "hirefire_time_range" "my_time_range" {
   manager_id = hirefire_manager.my_manager.id
 
-  email = "example@example.com"
   from_minute  = 415 // 06:55
   until_minute = 435 // 07:15
   minimum      = 5


### PR DESCRIPTION
The "email" param in the docs for `time_range` appears to be unused. Removing from the docs.