### PR TITLE
Add upscale_on_initial_job Manager attribute

### DIFF
--- a/client/manager.go
+++ b/client/manager.go
@@ -46,6 +46,7 @@ type Manager struct {
 	Notify               bool    `json:"notify"`
 	NotifyQuantity       int     `json:"notify_quantity"`
 	NotifyAfter          int     `json:"notify_after"`
+	UpscaleOnInitialJob  *bool   `json:"upscale_on_initial_job"`
 }
 
 type wrappedManager struct {

--- a/client/manager_test.go
+++ b/client/manager_test.go
@@ -1,11 +1,12 @@
 package client
 
 import (
-	"github.com/carwow/terraform-provider-hirefire/ptr"
-	"github.com/carwow/terraform-provider-hirefire/testing/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/carwow/terraform-provider-hirefire/ptr"
+	"github.com/carwow/terraform-provider-hirefire/testing/assert"
 )
 
 func TestGetManager(t *testing.T) {
@@ -57,38 +58,39 @@ func TestGetManagerEverything(t *testing.T) {
 				"minimum":        2,
 				"maximum":        5,
 
-				"aggregation":           "percentile",
-				"percentile":            99,
-				"minimum_latency":       100,
-				"maximum_latency":       150,
-				"minimum_queue_time":    200,
-				"maximum_queue_time":    400,
-				"minimum_response_time": 500,
-				"maximum_response_time": 1000,
-				"minimum_connect_time":  300,
-				"maximum_connect_time":  600,
-				"minimum_load":          1,
-				"maximum_load":          2,
-				"minimum_apdex":         95,
-				"maximum_apdex":         99,
-				"ratio":                 10,
-				"decrementable":         true,
-				"url":                   "https://www.example.com",
-				"upscale_quantity":      5,
-				"downscale_quantity":    1,
-				"upscale_sensitivity":   1,
-				"downscale_sensitivity": 2,
-				"upscale_timeout":       1,
-				"downscale_timeout":     2,
-				"upscale_limit":         0,
-				"downscale_limit":       2,
-				"scale_up_on_503":       true,
-				"new_relic_api_key":     "newrelic-api-key",
-				"new_relic_account_id":  "newrelic-account-id",
-				"new_relic_app_id":      "newrelic-app-id",
-				"notify":                true,
-				"notify_quantity":       5,
-				"notify_after":          10
+				"aggregation":            "percentile",
+				"percentile":             99,
+				"minimum_latency":        100,
+				"maximum_latency":        150,
+				"minimum_queue_time":     200,
+				"maximum_queue_time":     400,
+				"minimum_response_time":  500,
+				"maximum_response_time":  1000,
+				"minimum_connect_time":   300,
+				"maximum_connect_time":   600,
+				"minimum_load":           1,
+				"maximum_load":           2,
+				"minimum_apdex":          95,
+				"maximum_apdex":          99,
+				"ratio":                  10,
+				"decrementable":          true,
+				"url":                    "https://www.example.com",
+				"upscale_quantity":       5,
+				"downscale_quantity":     1,
+				"upscale_sensitivity":    1,
+				"downscale_sensitivity":  2,
+				"upscale_timeout":        1,
+				"downscale_timeout":      2,
+				"upscale_limit":          0,
+				"downscale_limit":        2,
+				"scale_up_on_503":        true,
+				"new_relic_api_key":      "newrelic-api-key",
+				"new_relic_account_id":   "newrelic-account-id",
+				"new_relic_app_id":       "newrelic-app-id",
+				"notify":                 true,
+				"notify_quantity":        5,
+				"notify_after":           10,
+				"upscale_on_initial_job": true
 			}
 		}`))
 	}))
@@ -141,6 +143,7 @@ func TestGetManagerEverything(t *testing.T) {
 		Notify:               true,
 		NotifyQuantity:       5,
 		NotifyAfter:          10,
+		UpscaleOnInitialJob:  ptr.Bool(true),
 	}
 	assert.Equals(t, expected, manager)
 }

--- a/docs/resources/manager.md
+++ b/docs/resources/manager.md
@@ -15,16 +15,17 @@ resource "hirefire_manager" "my_manager" {
   minimum = 2
   maximum = 10
 
-  aggregation           = "percentile"
-  percentile            = 99
-  minimum_queue_time    = 100
-  maximum_queue_time    = 250
-  downscale_quantity    = 1
-  upscale_quantity      = 5
-  downscale_sensitivity = 2
-  upscale_sensitivity   = 1
-  downscale_timeout     = 1
-  upscale_timeout       = 1
+  aggregation            = "percentile"
+  percentile             = 99
+  minimum_queue_time     = 100
+  maximum_queue_time     = 250
+  downscale_quantity     = 1
+  upscale_quantity       = 5
+  downscale_sensitivity  = 2
+  upscale_sensitivity    = 1
+  downscale_timeout      = 1
+  upscale_timeout        = 1
+  upscale_on_initial_job = true
 }
 ```
 
@@ -78,6 +79,7 @@ The following arguments are supported:
 - `downscale_sensitivity` - The amount of threshold breaches to wait before scaling down.
 - `upscale_timeout` - The amount of minutes to wait before performing upscale operations.
 - `downscale_timeout` - The amount of minutes to wait before performing downscale operations.
+- `upscale_on_initial_job` - Ensures the availability of at least one Dyno when one or more jobs are enqueued, bypassing the initial maximum latency requirement. Default is `true`.
 
 ### Manager::Web::Logplex::Load
 - `last_minutes` - The load average over the last n minutes. Possible values are `1`, `5`, and `15`.

--- a/resources/manager/resource.go
+++ b/resources/manager/resource.go
@@ -197,6 +197,10 @@ func Resource() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"upscale_on_initial_job": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -242,6 +246,7 @@ func setAttributes(d *schema.ResourceData, manager *client.Manager) {
 	d.Set("notify", manager.Notify)
 	d.Set("notify_quantity", manager.NotifyQuantity)
 	d.Set("notify_after", manager.NotifyAfter)
+	d.Set("upscale_on_initial_job", manager.UpscaleOnInitialJob)
 }
 
 func getAttributes(d *schema.ResourceData) client.Manager {
@@ -418,6 +423,11 @@ func getAttributes(d *schema.ResourceData) client.Manager {
 	if v, ok := d.GetOk("notify_after"); ok {
 		value := v.(int)
 		manager.NotifyAfter = value
+	}
+
+	if v, ok := d.GetOk("upscale_on_initial_job"); ok {
+		value := v.(bool)
+		manager.UpscaleOnInitialJob = &value
 	}
 
 	return manager


### PR DESCRIPTION
This new attribute for `Manager::Worker::HireFire::JobLatency` managers was added last September. It was only recently added to [the docs](https://docs.hirefire.io/#manager-worker-hirefire-joblatency), and are in need of it.

Thank you!

Closes #33 