### PR TITLE
Add in new_relic_region attribute

### DIFF
--- a/client/manager.go
+++ b/client/manager.go
@@ -44,6 +44,7 @@ type Manager struct {
 	NewRelicApiKey       *string `json:"new_relic_api_key"`
 	NewRelicAccountId    *string `json:"new_relic_account_id"`
 	NewRelicAppId        *string `json:"new_relic_app_id"`
+	NewRelicRegion       *string `json:"new_relic_region"`
 	Notify               bool    `json:"notify"`
 	NotifyQuantity       int     `json:"notify_quantity"`
 	NotifyAfter          int     `json:"notify_after"`

--- a/client/manager_test.go
+++ b/client/manager_test.go
@@ -88,6 +88,7 @@ func TestGetManagerEverything(t *testing.T) {
 				"new_relic_api_key":      "newrelic-api-key",
 				"new_relic_account_id":   "newrelic-account-id",
 				"new_relic_app_id":       "newrelic-app-id",
+				"new_relic_region":       "newrelic-region",
 				"notify":                 true,
 				"notify_quantity":        5,
 				"notify_after":           10
@@ -141,6 +142,7 @@ func TestGetManagerEverything(t *testing.T) {
 		NewRelicApiKey:       ptr.String("newrelic-api-key"),
 		NewRelicAccountId:    ptr.String("newrelic-account-id"),
 		NewRelicAppId:        ptr.String("newrelic-app-id"),
+		NewRelicRegion:       ptr.String("newrelic-region"),
 		Notify:               true,
 		NotifyQuantity:       5,
 		NotifyAfter:          10,

--- a/docs/resources/manager.md
+++ b/docs/resources/manager.md
@@ -147,6 +147,7 @@ The following arguments are supported:
 - `new_relic_api_key` - New Relic api key.
 - `new_relic_app_id` - New Relic application id.
 - `new_relic_account_id` - V1 only. New Relic account id.
+- `new_relic_region` - V2 only. New Relic region.
 
 ### Manager::Web::NewRelic::V2::RPM (and V1)
 - `ratio` - Maintains a web:rpm ratio by scaling based on requests per minute.
@@ -157,6 +158,7 @@ The following arguments are supported:
 - `new_relic_api_key` - New Relic api key.
 - `new_relic_app_id` - New Relic application id.
 - `new_relic_account_id` - V1 only. New Relic account id.
+- `new_relic_region` - V2 only. New Relic region.
 
 ### Manager::Web::NewRelic::V2::Apdex (and V1)
 - `minimum_apdex` - Scales up if your application's apdex goes below this amount.
@@ -171,6 +173,7 @@ The following arguments are supported:
 - `new_relic_api_key` - New Relic api key.
 - `new_relic_app_id` - New Relic application id.
 - `new_relic_account_id` - V1 only. New Relic account id.
+- `new_relic_region` - V2 only. New Relic region.
 
 ### Manager::Web::HireFire::ResponseTime
 - `url` - Specific URL to measure.

--- a/resources/manager/resource.go
+++ b/resources/manager/resource.go
@@ -189,6 +189,10 @@ func Resource() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"new_relic_region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"notify": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -244,6 +248,7 @@ func setAttributes(d *schema.ResourceData, manager *client.Manager) {
 	d.Set("new_relic_api_key", manager.NewRelicApiKey)
 	d.Set("new_relic_account_id", manager.NewRelicAccountId)
 	d.Set("new_relic_app_id", manager.NewRelicAppId)
+	d.Set("new_relic_region", manager.NewRelicRegion)
 	d.Set("notify", manager.Notify)
 	d.Set("notify_quantity", manager.NotifyQuantity)
 	d.Set("notify_after", manager.NotifyAfter)
@@ -413,6 +418,11 @@ func getAttributes(d *schema.ResourceData) client.Manager {
 	if v, ok := d.GetOk("new_relic_app_id"); ok {
 		value := v.(string)
 		manager.NewRelicAppId = &value
+	}
+
+	if v, ok := d.GetOk("new_relic_region"); ok {
+		value := v.(string)
+		manager.NewRelicRegion = &value
 	}
 
 	if v, ok := d.GetOk("notify"); ok {

--- a/resources/manager/resource_test.go
+++ b/resources/manager/resource_test.go
@@ -334,6 +334,7 @@ func checkAttributes(manager client.Manager) resource.TestCheckFunc {
 		"new_relic_api_key":      helper.StringOrEmpty(manager.NewRelicApiKey),
 		"new_relic_account_id":   helper.StringOrEmpty(manager.NewRelicAccountId),
 		"new_relic_app_id":       helper.StringOrEmpty(manager.NewRelicAppId),
+		"new_relic_region":       helper.StringOrEmpty(manager.NewRelicRegion),
 		"notify":                 strconv.FormatBool(manager.Notify),
 		"notify_quantity":        strconv.Itoa(manager.NotifyQuantity),
 		"notify_after":           strconv.Itoa(manager.NotifyAfter),


### PR DESCRIPTION
This PR adds in the `new_relic_region` attribute to fix New Relic Hirefire manager creation as mentioned in https://github.com/carwow/terraform-provider-hirefire/issues/41. I believe that the code changes are complete since I mainly copied/pasted from the other New Relic params, although I haven't tested the changes at this point. If someone gets back to this before I do, feel free to test/fix the changes.